### PR TITLE
Fix for requirements not installing when torchaudio is already present in venv

### DIFF
--- a/install.py
+++ b/install.py
@@ -9,17 +9,17 @@ req_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "requiremen
 print("Initializing Riffusion")
 riffusion_skip_install = os.environ.get("RIFFUSION_SKIP_INSTALL", False)
 
-if not riffusion_skip_install and not launch.is_installed("torchaudio"):
+if not riffusion_skip_install:
     name = "Riffusion"
-    if platform.system() == "Darwin":
-        # MacOS
-        launch.run(
-            f'"{sys.executable}" -m pip install torchaudio==0.13.1',
-            f"[{name}] Installing torchaudio...",
-            f"[{name}] Couldn't install torchaudio.",
-        )
-    else:
-        if torch.version.hip:
+    if not launch.is_installed("torchaudio"):
+        if platform.system() == "Darwin":
+            # MacOS
+            launch.run(
+                f'"{sys.executable}" -m pip install torchaudio==0.13.1',
+                f"[{name}] Installing torchaudio...",
+                f"[{name}] Couldn't install torchaudio.",
+            )
+        elif torch.version.hip:
             launch.run(
                 f'"{sys.executable}" -m pip install torchaudio==0.13.1+rocm5.2 --extra-index-url https://download.pytorch.org/whl/rocm5.2',
                 f"[{name}] Installing torchaudio...",

--- a/scripts/riffusion.py
+++ b/scripts/riffusion.py
@@ -345,6 +345,7 @@ def convert_audio(image_dir: str, file_regex: str, join_images: bool) -> None:
         output_files.append(convert_audio_file(image, image_dir))
 
     if join_images and len(output_files) > 1:
+        output_files.sort()
         data = []
         outfile = os.path.join(
             image_dir,


### PR DESCRIPTION
If torchaudio is already installed, requirements don't install and extension cannot be used. This should fix this issue.