### PR TITLE
Added option for cropping samples to a set width or detect it from beats

### DIFF
--- a/scripts/riffusion.py
+++ b/scripts/riffusion.py
@@ -20,7 +20,7 @@ import glob
 from datetime import datetime
 import wave
 import platform
-from statistics import mean
+from statistics import mean, median
 
 base_dir = scripts.basedir()
 
@@ -321,7 +321,7 @@ class RiffusionScript(scripts.Script):
 
 def convert_audio_file(image, output_dir, crop_width = None):
     image_file = Image.open(image)
-    return convert_audio_image(image, image_file_, output_dir_, crop_width)
+    return convert_audio_image(image, image_file, output_dir, crop_width)
 
 def convert_audio_image(image, image_file, output_dir, crop_width = None):
     if crop_width is not None and crop_width < image_file.width:
@@ -398,7 +398,7 @@ def find_cutoff(image, rhythm = 4, band_start = 0.25, band_end = 0.75, threshold
     one_line = list(gray_image.resize((gray_image.width, 1)).getdata())
     one_pixel = list(gray_image.resize((1, 1)).getdata())
     average = one_pixel[0]
-    threshold = average - (256 - average) * threshold_offset
+    threshold = min(one_line) + (max(one_line) - min(one_line)) * threshold_offset
     above_threshold = []
     for i, value in enumerate(one_line):
         if value < threshold and (len(above_threshold) == 0 or i - above_threshold[-1] > ignore_distance):
@@ -417,7 +417,7 @@ def find_cutoff(image, rhythm = 4, band_start = 0.25, band_end = 0.75, threshold
 
         distances.append(value - above_threshold[i - 1])
     
-    distance = mean(distances)
+    distance = median(distances)
     print("Interval:", distance)
 
     beat_count = int(len(above_threshold) / rhythm) * rhythm
@@ -492,7 +492,7 @@ def on_ui_tabs():
                     with gr.Row():
                         threshold_offset = gr.Number(
                             label="Threshold offset",
-                            value=0.35,
+                            value=0.1,
                             precision=2,
                             interactive=True,
                         )

--- a/scripts/riffusion.py
+++ b/scripts/riffusion.py
@@ -342,7 +342,7 @@ def convert_audio(
     join_images: bool,
     crop_method: str,
     crop_width: int,
-    rythm:int,
+    rhythm:int,
     band_start: float,
     band_end: float,
     threshold_offset: float,
@@ -363,7 +363,7 @@ def convert_audio(
         if crop_method == "Fixed":
             width = crop_width
         elif crop_method.startswith("Beat Finder") and (not crop_method.endswith("(Once)") or i == 0):
-            width = find_cutoff(image_file, rythm, band_start, band_end, threshold_offset, ignore_range)
+            width = find_cutoff(image_file, rhythm, band_start, band_end, threshold_offset, ignore_range)
             print("Cutoff found at:", width)
         
         output_files.append(convert_audio_image(image, image_file, image_dir, width))
@@ -387,7 +387,7 @@ def convert_audio(
 
     print(f"Converted {len(images)} images to audio")
 
-def find_cutoff(image, rythm = 4, band_start = 0.25, band_end = 0.75, threshold_offset = 0.75, ignore_range = 0.05):
+def find_cutoff(image, rhythm = 4, band_start = 0.25, band_end = 0.75, threshold_offset = 0.75, ignore_range = 0.05):
     
     ignore_distance = image.width * ignore_range
     register_start = image.height * band_start
@@ -405,8 +405,11 @@ def find_cutoff(image, rythm = 4, band_start = 0.25, band_end = 0.75, threshold_
             above_threshold.append(i)
     
     if len(above_threshold) == 0:
+        print("Failed to find beats")
         return None
-    
+
+    print("Beats found:", above_threshold)
+
     distances = []
     for i, value in enumerate(above_threshold):
         if i == 0:
@@ -415,8 +418,11 @@ def find_cutoff(image, rythm = 4, band_start = 0.25, band_end = 0.75, threshold_
         distances.append(value - above_threshold[i - 1])
     
     distance = mean(distances)
-    beat_count = int(len(above_threshold) / rythm) * rythm
+    print("Interval:", distance)
+
+    beat_count = int(len(above_threshold) / rhythm) * rhythm
     if beat_count == 0:
+        print("Missmatching rhythm")
         return None
 
     cutoff = int(beat_count * distance)
@@ -463,8 +469,8 @@ def on_ui_tabs():
 
                 with gr.Column(visible=False) as beat_finder_block:
                     with gr.Row():
-                        rythm = gr.Number(
-                            label="Rythm",
+                        rhythm = gr.Number(
+                            label="Rhythm",
                             value=4,
                             precision=0,
                             interactive=True,
@@ -479,21 +485,21 @@ def on_ui_tabs():
 
                         band_end = gr.Number(
                             label="Band end",
-                            value=0.75,
+                            value=0.5,
                             precision=2,
                             interactive=True,
                         )
                     with gr.Row():
                         threshold_offset = gr.Number(
                             label="Threshold offset",
-                            value=0.75,
+                            value=0.35,
                             precision=2,
                             interactive=True,
                         )
 
                         ignore_range = gr.Number(
                             label="Ignore range",
-                            value=0.05,
+                            value=0.1,
                             precision=23,
                             interactive=True,
                         )
@@ -512,7 +518,7 @@ def on_ui_tabs():
                             join_images,
                             crop_method,
                             crop_width,
-                            rythm,
+                            rhythm,
                             band_start,
                             band_end,
                             threshold_offset,


### PR DESCRIPTION
I've added an option for cropping samples (actually images right before being converted into WAV) in the Riffusion tab. This can be useful when samples (like the ones produced by prompt travel) have excess length (appears to be most of the time for me). Cropped samples join more seamlessly.

There are two main options for cropping samples:

- Fixed width - you can open one generated image (preferably first) in an image manipulation program of your choice and eye where the excess begins
- Beat finder - I've made a somewhat naive algorithm for estimating where the sample should end. You input which horizontal slice of the image to check, find indexes with values above threshold (with certain minimum distance) and count beats to match a set rhythm, There isn't one set of parameters that fits all samples, but I've added a visualization for the beat finder to help tweak them to your need.

![image](https://user-images.githubusercontent.com/8976334/235325931-0f8ac6eb-9d56-4f32-8ad1-c6e0960d73bd.png)
Image generated by the visualization (after getting settings just right).

This could be further improved by checking local maxima instead of just threshold (it's somewhat visible on the image, beats are detected when threshold is satisfied rather on the peak). Also, it might be possible to automate finding some of the settings (like horizontal slice or threshold).

If the code needs cleaning up, leave me a comment.